### PR TITLE
Fix modules structure backward compatibility with CUBA Platform prior to 7.1 version

### DIFF
--- a/modules/global/src/com/haulmont/addon/restapi/app-component.xml
+++ b/modules/global/src/com/haulmont/addon/restapi/app-component.xml
@@ -35,13 +35,16 @@
                   value="+com/haulmont/addon/restapi/remoting-spring.xml"/>
     </module>
 
-    <module name="web" dependsOn="global" blocks="web">
-        <artifact name="restapi-web" appJar="true"/>
+    <module name="rest-api" dependsOn="global" blocks="web,portal">
         <artifact name="restapi-rest-api" appJar="true"/>
-        <artifact name="restapi-web" classifier="web" ext="zip" configuration="webcontent"/>
-
         <property name="cuba.restSpringContextConfig"
                   value="+com/haulmont/addon/restapi/rest-dispatcher-spring.xml"/>
+    </module>
+
+    <module name="web" dependsOn="rest-api" blocks="web">
+        <artifact name="restapi-web" appJar="true"/>
+        <artifact name="restapi-web" classifier="web" ext="zip" configuration="webcontent"/>
+
         <property name="cuba.springContextConfig"
                   value="+com/haulmont/addon/restapi/web-spring.xml"/>
         <property name="cuba.permissionConfig"
@@ -61,12 +64,9 @@
         <property name="cuba.rest.responseViewEnabled" value="true"/>
     </module>
 
-    <module name="portal" dependsOn="global" blocks="portal">
+    <module name="portal" dependsOn="rest-api" blocks="portal">
         <artifact name="restapi-portal" appJar="true"/>
-        <artifact name="restapi-rest-api" appJar="true"/>
 
-        <property name="cuba.restSpringContextConfig"
-                  value="+com/haulmont/addon/restapi/rest-dispatcher-spring.xml"/>
         <property name="cuba.springContextConfig"
                   value="+com/haulmont/addon/restapi/portal-spring.xml"/>
 


### PR DESCRIPTION
In CUBA Platform prior to 7.1 version the `rest-api` was defined in `app-component.xml` as "first-class" separate module. Developers could rely on such a structure and create dependent modules in their applications. 

Now REST API addon define `rest-api` only as `appJar` in `web` and `portal` modules, so backward compatibility with previous versions of platform is broken.