### PR TITLE
added httpMethod to RestServicesConfiguration

### DIFF
--- a/modules/rest-api/src/com/haulmont/addon/restapi/api/auth/CubaAnonymousAuthenticationFilter.java
+++ b/modules/rest-api/src/com/haulmont/addon/restapi/api/auth/CubaAnonymousAuthenticationFilter.java
@@ -119,7 +119,7 @@ public class CubaAnonymousAuthenticationFilter implements Filter {
                             return;
                         }
                         RestServicesConfiguration.RestMethodInfo restMethodInfo = restServicesConfiguration
-                                .getRestMethodInfo(serviceName, methodName, methodParamNames);
+                                .getRestMethodInfo(serviceName, methodName, methodParamNames, methodType);
                         if (restMethodInfo != null && restMethodInfo.isAnonymousAllowed()) {
                             populateSecurityContextWithAnonymousSession();
                         }

--- a/modules/rest-api/src/com/haulmont/addon/restapi/api/service/ServicesControllerManager.java
+++ b/modules/rest-api/src/com/haulmont/addon/restapi/api/service/ServicesControllerManager.java
@@ -32,6 +32,7 @@ import com.haulmont.cuba.core.global.AppBeans;
 import com.haulmont.cuba.core.global.Metadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
@@ -80,7 +81,7 @@ public class ServicesControllerManager {
         paramsMap.remove("modelVersion");
         List<String> paramNames = new ArrayList<>(paramsMap.keySet());
         List<String> paramValuesStr = new ArrayList<>(paramsMap.values());
-        return _invokeServiceMethod(serviceName, methodName, paramNames, paramValuesStr, modelVersion);
+        return _invokeServiceMethod(serviceName, methodName, paramNames, paramValuesStr, modelVersion, HttpMethod.GET);
     }
 
     @Nullable
@@ -91,7 +92,7 @@ public class ServicesControllerManager {
         Map<String, String> paramsMap = restParseUtils.parseParamsJson(paramsJson);
         List<String> paramNames = new ArrayList<>(paramsMap.keySet());
         List<String> paramValuesStr = new ArrayList<>(paramsMap.values());
-        return _invokeServiceMethod(serviceName, methodName, paramNames, paramValuesStr, modelVersion);
+        return _invokeServiceMethod(serviceName, methodName, paramNames, paramValuesStr, modelVersion, HttpMethod.POST);
     }
 
     public Collection<RestServicesConfiguration.RestServiceInfo> getServiceInfos() {
@@ -113,9 +114,10 @@ public class ServicesControllerManager {
                                                      String methodName,
                                                      List<String> paramNames,
                                                      List<String> paramValuesStr,
-                                                     String modelVersion) throws Throwable {
+                                                     String modelVersion,
+                                                     HttpMethod paramHttpMethod) throws Throwable {
         Object service = AppBeans.get(serviceName);
-        RestServicesConfiguration.RestMethodInfo restMethodInfo = restServicesConfiguration.getRestMethodInfo(serviceName, methodName, paramNames);
+        RestServicesConfiguration.RestMethodInfo restMethodInfo = restServicesConfiguration.getRestMethodInfo(serviceName, methodName, paramNames, paramHttpMethod.name());
         if (restMethodInfo == null) {
             throw new RestAPIException("Service method not found",
                     serviceName + "." + methodName + "(" + paramNames.stream().collect(Collectors.joining(",")) + ")",

--- a/modules/rest-api/src/com/haulmont/addon/restapi/api/xsd/rest-services-v2.xsd
+++ b/modules/rest-api/src/com/haulmont/addon/restapi/api/xsd/rest-services-v2.xsd
@@ -42,6 +42,7 @@
         </xs:sequence>
         <xs:attribute name="name" type="xs:string" use="required"/>
         <xs:attribute name="anonymousAllowed" type="xs:string"/>
+        <xs:attribute name="httpMethod" type="xs:string"/>
     </xs:complexType>
 
     <xs:complexType name="methodParamType">


### PR DESCRIPTION
With this pull request it is possible to add an (optional) http method parameter to the rest services configuration. When `httpMethod` is provided, only requests with this http method are processed.