### PR TITLE
Backport REST files fix

### DIFF
--- a/modules/global/src/com/haulmont/addon/restapi/api/config/RestApiConfig.java
+++ b/modules/global/src/com/haulmont/addon/restapi/api/config/RestApiConfig.java
@@ -21,6 +21,7 @@ import com.haulmont.cuba.core.config.Config;
 import com.haulmont.cuba.core.config.Property;
 import com.haulmont.cuba.core.config.Source;
 import com.haulmont.cuba.core.config.SourceType;
+import com.haulmont.cuba.core.config.defaults.Default;
 import com.haulmont.cuba.core.config.defaults.DefaultBoolean;
 import com.haulmont.cuba.core.config.defaults.DefaultString;
 import com.haulmont.cuba.core.config.type.CommaSeparatedStringListTypeFactory;
@@ -123,4 +124,12 @@ public interface RestApiConfig extends Config {
     @Factory(factory = UuidTypeFactory.class)
     @Nullable
     UUID getRestAnonymousSessionId();
+
+    /**
+     * File extensions that can be opened for viewing in a browser by replying with 'Content-Disposition=inline' header.
+     */
+    @Property("cuba.rest.inlineEnabledFileExtensions")
+    @Factory(factory = CommaSeparatedStringListTypeFactory.class)
+    @Default("jpg, png, jpeg, pdf")
+    List<String> getInlineEnabledFileExtensions();
 }

--- a/modules/rest-api/src/com/haulmont/addon/restapi/api/controllers/FileDownloadController.java
+++ b/modules/rest-api/src/com/haulmont/addon/restapi/api/controllers/FileDownloadController.java
@@ -39,8 +39,7 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -152,7 +151,7 @@ public class FileDownloadController {
             return true;
         } else {
             // Check if file is allowed to be opened inline
-            Set<String> inlineEnabledFileExtensions = new HashSet<>(restApiConfig.getInlineEnabledFileExtensions());
+            List<String> inlineEnabledFileExtensions = restApiConfig.getInlineEnabledFileExtensions();
             return !inlineEnabledFileExtensions.contains(StringUtils.lowerCase(extension));
         }
     }


### PR DESCRIPTION
See #147.

Path traversal issue is irrelevant due to providing ID of FileDescriptor, not path within FileRef.